### PR TITLE
feat: add suspendWithIamAccount to Blogs AccountsService

### DIFF
--- a/src/Services/AccountsService.php
+++ b/src/Services/AccountsService.php
@@ -41,4 +41,26 @@ class AccountsService extends AbstractAccountsService
 
         return $accounts;
     }
+
+    /**
+     * Suspends the Blogs account belonging to the given IAM account, if one
+     * exists. Blogs accounts are opt-in, so a customer without one is a
+     * no-op here, not an error.
+     */
+    public static function suspendWithIamAccount(\NextDeveloper\IAM\Database\Models\Accounts $account): ?Accounts
+    {
+        $blogAccount = Accounts::withoutGlobalScope(AuthorizationScope::class)
+            ->where('iam_account_id', $account->id)
+            ->first();
+
+        if (!$blogAccount) {
+            return null;
+        }
+
+        $blogAccount->update([
+            'is_suspended' => true,
+        ]);
+
+        return $blogAccount->fresh();
+    }
 }


### PR DESCRIPTION
## Summary
- Wires the Blogs module into the CRM account-suspension flow (`SuspendAccountAndServices` in plusclouds.api.v4) by adding `AccountsService::suspendWithIamAccount()`.
- Sets `is_suspended = true` for the account tied to the given IAM account; no-op if the customer never had a Blogs account (opt-in module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)