### PR TITLE
Fix: explicit nullable parameter types (PHP 8.4 deprecation)

### DIFF
--- a/src/Authorization/Roles/BlogReaderRole.php
+++ b/src/Authorization/Roles/BlogReaderRole.php
@@ -38,7 +38,7 @@ class BlogReaderRole extends AbstractRole implements IAuthorizationRole
         }
     }
 
-    public function checkPrivileges(Users $users = null)
+    public function checkPrivileges(?Users $users = null)
     {
         //return UserHelper::hasRole(self::NAME, $users);
     }

--- a/src/Database/Filters/AccountsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/AccountsPerspectiveQueryFilter.php
@@ -37,13 +37,13 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -54,7 +54,7 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function isSuspended($value)
     {
         return $this->builder->where('is_suspended', $value);
@@ -65,7 +65,7 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isSuspended($value);
     }
-     
+
     public function isAutoTranslateEnabled($value)
     {
         return $this->builder->where('is_auto_translate_enabled', $value);
@@ -76,7 +76,7 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isAutoTranslateEnabled($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -157,7 +157,7 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function commonLanguageId($value)
     {
             $commonLanguage = \NextDeveloper\Commons\Database\Models\Languages::where('uuid', $value)->first();
@@ -172,7 +172,7 @@ class AccountsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonLanguage($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/AccountsQueryFilter.php
+++ b/src/Database/Filters/AccountsQueryFilter.php
@@ -28,7 +28,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
     {
         return $this->isSuspended($value);
     }
-     
+
     public function isAutoTranslateEnabled($value)
     {
         return $this->builder->where('is_auto_translate_enabled', $value);
@@ -39,7 +39,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
     {
         return $this->isAutoTranslateEnabled($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -120,7 +120,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function commonLanguageId($value)
     {
             $commonLanguage = \NextDeveloper\Commons\Database\Models\Languages::where('uuid', $value)->first();
@@ -135,7 +135,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonLanguage($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -145,7 +145,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/PostSlugHistoriesQueryFilter.php
+++ b/src/Database/Filters/PostSlugHistoriesQueryFilter.php
@@ -17,13 +17,13 @@ class PostSlugHistoriesQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -104,7 +104,7 @@ class PostSlugHistoriesQueryFilter extends AbstractQueryFilter
     {
         return $this->blogPost($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -114,7 +114,7 @@ class PostSlugHistoriesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -124,7 +124,7 @@ class PostSlugHistoriesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/PostsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/PostsPerspectiveQueryFilter.php
@@ -37,31 +37,31 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function body($value)
     {
         return $this->builder->where('body', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function abstract($value)
     {
         return $this->builder->where('abstract', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function headerImage($value)
     {
         return $this->builder->where('header_image', 'ilike', '%' . $value . '%');
@@ -72,7 +72,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->headerImage($value);
     }
-        
+
     public function metaTitle($value)
     {
         return $this->builder->where('meta_title', 'ilike', '%' . $value . '%');
@@ -83,7 +83,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->metaTitle($value);
     }
-        
+
     public function metaDescription($value)
     {
         return $this->builder->where('meta_description', 'ilike', '%' . $value . '%');
@@ -94,7 +94,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->metaDescription($value);
     }
-        
+
     public function metaKeywords($value)
     {
         return $this->builder->where('meta_keywords', 'ilike', '%' . $value . '%');
@@ -105,31 +105,31 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->metaKeywords($value);
     }
-        
+
     public function locale($value)
     {
         return $this->builder->where('locale', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function author($value)
     {
         return $this->builder->where('author', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function team($value)
     {
         return $this->builder->where('team', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function category($value)
     {
         return $this->builder->where('category', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function domainName($value)
     {
         return $this->builder->where('domain_name', 'ilike', '%' . $value . '%');
@@ -140,7 +140,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->domainName($value);
     }
-    
+
     public function replyCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -159,7 +159,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->replyCount($value);
     }
-    
+
     public function readCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -178,7 +178,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->readCount($value);
     }
-    
+
     public function bonusPoints($value)
     {
         $operator = substr($value, 0, 1);
@@ -197,7 +197,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->bonusPoints($value);
     }
-    
+
     public function alternateOf($value)
     {
         $operator = substr($value, 0, 1);
@@ -216,7 +216,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->alternateOf($value);
     }
-    
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -227,7 +227,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function isLocked($value)
     {
         return $this->builder->where('is_locked', $value);
@@ -238,7 +238,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isLocked($value);
     }
-     
+
     public function isPinned($value)
     {
         return $this->builder->where('is_pinned', $value);
@@ -249,7 +249,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPinned($value);
     }
-     
+
     public function isDraft($value)
     {
         return $this->builder->where('is_draft', $value);
@@ -260,7 +260,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isDraft($value);
     }
-     
+
     public function isMarkdown($value)
     {
         return $this->builder->where('is_markdown', $value);
@@ -271,7 +271,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isMarkdown($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -347,7 +347,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -357,7 +357,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function commonDomainId($value)
     {
             $commonDomain = \NextDeveloper\Commons\Database\Models\Domains::where('uuid', $value)->first();
@@ -372,7 +372,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function commonCategoryId($value)
     {
             $commonCategory = \NextDeveloper\Commons\Database\Models\Categories::where('uuid', $value)->first();
@@ -387,7 +387,7 @@ class PostsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/PostsQueryFilter.php
+++ b/src/Database/Filters/PostsQueryFilter.php
@@ -37,25 +37,25 @@ class PostsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function title($value)
     {
         return $this->builder->where('title', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function body($value)
     {
         return $this->builder->where('body', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function headerImage($value)
     {
         return $this->builder->where('header_image', 'ilike', '%' . $value . '%');
@@ -66,7 +66,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->headerImage($value);
     }
-        
+
     public function metaTitle($value)
     {
         return $this->builder->where('meta_title', 'ilike', '%' . $value . '%');
@@ -77,7 +77,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->metaTitle($value);
     }
-        
+
     public function metaDescription($value)
     {
         return $this->builder->where('meta_description', 'ilike', '%' . $value . '%');
@@ -88,7 +88,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->metaDescription($value);
     }
-        
+
     public function metaKeywords($value)
     {
         return $this->builder->where('meta_keywords', 'ilike', '%' . $value . '%');
@@ -99,19 +99,19 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->metaKeywords($value);
     }
-        
+
     public function abstract($value)
     {
         return $this->builder->where('abstract', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function locale($value)
     {
         return $this->builder->where('locale', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function replyCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -130,7 +130,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->replyCount($value);
     }
-    
+
     public function readCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -149,7 +149,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->readCount($value);
     }
-    
+
     public function bonusPoints($value)
     {
         $operator = substr($value, 0, 1);
@@ -168,7 +168,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->bonusPoints($value);
     }
-    
+
     public function alternateOf($value)
     {
         $operator = substr($value, 0, 1);
@@ -187,7 +187,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->alternateOf($value);
     }
-    
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -198,7 +198,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function isLocked($value)
     {
         return $this->builder->where('is_locked', $value);
@@ -209,7 +209,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->isLocked($value);
     }
-     
+
     public function isPinned($value)
     {
         return $this->builder->where('is_pinned', $value);
@@ -220,7 +220,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPinned($value);
     }
-     
+
     public function isDraft($value)
     {
         return $this->builder->where('is_draft', $value);
@@ -231,7 +231,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->isDraft($value);
     }
-     
+
     public function isMarkdown($value)
     {
         return $this->builder->where('is_markdown', $value);
@@ -242,7 +242,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->isMarkdown($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -318,7 +318,7 @@ class PostsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -328,7 +328,7 @@ class PostsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function commonCategoryId($value)
     {
             $commonCategory = \NextDeveloper\Commons\Database\Models\Categories::where('uuid', $value)->first();
@@ -343,7 +343,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function commonDomainId($value)
     {
             $commonDomain = \NextDeveloper\Commons\Database\Models\Domains::where('uuid', $value)->first();
@@ -358,7 +358,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function blogAccountId($value)
     {
             $blogAccount = \NextDeveloper\Blogs\Database\Models\Accounts::where('uuid', $value)->first();
@@ -373,7 +373,7 @@ class PostsQueryFilter extends AbstractQueryFilter
     {
         return $this->blogAccount($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/PostSlugHistories.php
+++ b/src/Database/Models/PostSlugHistories.php
@@ -140,7 +140,7 @@ class PostSlugHistories extends Model
     {
         return $this->belongsTo(\NextDeveloper\Blogs\Database\Models\Posts::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Posts.php
+++ b/src/Database/Models/Posts.php
@@ -207,22 +207,22 @@ class Posts extends Model
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function categories() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Categories::class);
     }
-    
+
     public function domains() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Domains::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function postSlugHistories() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Blogs\Database\Models\PostSlugHistories::class);

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsPerspectiveTransformer.php
@@ -56,7 +56,7 @@ class AbstractAccountsPerspectiveTransformer extends AbstractTransformer
     {
                                                 $commonDomainId = \NextDeveloper\Commons\Database\Models\Domains::where('id', $model->common_domain_id)->first();
                                                             $commonLanguageId = \NextDeveloper\Commons\Database\Models\Languages::where('id', $model->common_language_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
@@ -57,7 +57,7 @@ class AbstractAccountsTransformer extends AbstractTransformer
                                                 $commonDomainId = \NextDeveloper\Commons\Database\Models\Domains::where('id', $model->common_domain_id)->first();
                                                             $commonLanguageId = \NextDeveloper\Commons\Database\Models\Languages::where('id', $model->common_language_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractPostSlugHistoriesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPostSlugHistoriesTransformer.php
@@ -57,7 +57,7 @@ class AbstractPostSlugHistoriesTransformer extends AbstractTransformer
                                                 $blogPostId = \NextDeveloper\Blogs\Database\Models\Posts::where('id', $model->blog_post_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractPostsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPostsPerspectiveTransformer.php
@@ -58,7 +58,7 @@ class AbstractPostsPerspectiveTransformer extends AbstractTransformer
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $commonDomainId = \NextDeveloper\Commons\Database\Models\Domains::where('id', $model->common_domain_id)->first();
                                                             $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractPostsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractPostsTransformer.php
@@ -59,7 +59,7 @@ class AbstractPostsTransformer extends AbstractTransformer
                                                             $commonCategoryId = \NextDeveloper\Commons\Database\Models\Categories::where('id', $model->common_category_id)->first();
                                                             $commonDomainId = \NextDeveloper\Commons\Database\Models\Domains::where('id', $model->common_domain_id)->first();
                                                             $blogAccountId = \NextDeveloper\Blogs\Database\Models\Accounts::where('id', $model->blog_account_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Services/AbstractServices/AbstractAccountsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractAccountsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractAccountsPerspectiveService
 {
-    public static function get(AccountsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?AccountsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -179,7 +179,7 @@ class AbstractAccountsPerspectiveService
      */
     public static function create(array $data)
     {
-        
+
         try {
             $model = AccountsPerspective::create($data);
         } catch(\Exception $e) {
@@ -225,7 +225,7 @@ class AbstractAccountsPerspectiveService
             );
         }
 
-        
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractAccountsService.php
+++ b/src/Services/AbstractServices/AbstractAccountsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractAccountsService
 {
-    public static function get(AccountsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?AccountsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractPostSlugHistoriesService.php
+++ b/src/Services/AbstractServices/AbstractPostSlugHistoriesService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractPostSlugHistoriesService
 {
-    public static function get(PostSlugHistoriesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?PostSlugHistoriesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -196,7 +196,7 @@ class AbstractPostSlugHistoriesService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -206,11 +206,11 @@ class AbstractPostSlugHistoriesService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = PostSlugHistories::create($data);
         } catch(\Exception $e) {
@@ -274,7 +274,7 @@ class AbstractPostSlugHistoriesService
                 $data['iam_user_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractPostsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractPostsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractPostsPerspectiveService
 {
-    public static function get(PostsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?PostsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -278,7 +278,7 @@ class AbstractPostsPerspectiveService
                 $data['common_category_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Blogs\PostsPerspective', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractPostsService.php
+++ b/src/Services/AbstractServices/AbstractPostsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractPostsService
 {
-    public static function get(PostsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?PostsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -212,7 +212,7 @@ class AbstractPostsService
                 $data['blog_account_id']
             );
         }
-                        
+
         try {
             $model = Posts::create($data);
         } catch(\Exception $e) {
@@ -290,7 +290,7 @@ class AbstractPostsService
                 $data['blog_account_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Blogs\Posts', $model);
 
         try {

--- a/src/Services/PostsPerspectiveService.php
+++ b/src/Services/PostsPerspectiveService.php
@@ -19,7 +19,7 @@ class PostsPerspectiveService extends AbstractPostsPerspectiveService
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
-    public static function get(PostsPerspectiveQueryFilter $filter = null, array $params = []): \Illuminate\Database\Eloquent\Collection|\Illuminate\Contracts\Pagination\LengthAwarePaginator
+    public static function get(?PostsPerspectiveQueryFilter $filter = null, array $params = []): \Illuminate\Database\Eloquent\Collection|\Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         $list = parent::get($filter, $params);
 


### PR DESCRIPTION
Applies Rector's ExplicitNullableParamTypeRector across the package: `Type $x = null` -> `?Type $x = null`. Fixes the PHP 8.4 implicit-nullable-parameter deprecation notice.