### PR TITLE
docs: add DDL schema files for module tables and views

### DIFF
--- a/schemas/blog_accounts.sql
+++ b/schemas/blog_accounts.sql
@@ -1,0 +1,19 @@
+-- PostgreSQL
+-- The blog accounts that are used to manage the blog content.
+
+CREATE TABLE blog_accounts (
+    id                         bigint NOT NULL DEFAULT nextval('blog_accounts_id_seq'::regclass),
+    uuid                       uuid NOT NULL DEFAULT gen_random_uuid(),
+    limits                     text[],
+    is_suspended               boolean DEFAULT false,
+    created_at                 timestamp with time zone DEFAULT now(),
+    updated_at                 timestamp with time zone DEFAULT now(),
+    deleted_at                 timestamp with time zone,
+    alternate                  json NOT NULL DEFAULT '{"blog_account_ids": []}'::jsonb, -- The alternate translation configuration for the blog content.
+    common_domain_id           bigint NOT NULL,
+    is_auto_translate_enabled  boolean DEFAULT true, -- The flag to enable automatic translation of the blog content.
+    common_language_id         bigint,
+    iam_account_id             bigint,
+    CONSTRAINT blog_accounts_pkey PRIMARY KEY (id),
+    CONSTRAINT blog_accounts_common_domain_id_key UNIQUE (common_domain_id)
+);

--- a/schemas/blog_accounts_perspective.sql
+++ b/schemas/blog_accounts_perspective.sql
@@ -1,0 +1,20 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW blog_accounts_perspective AS
+SELECT ba.id,
+    ba.uuid,
+    cd.name,
+    cd.is_active,
+    cd.tags,
+    ba.common_domain_id,
+    ba.common_language_id,
+    ba.limits,
+    ba.is_suspended,
+    ba.is_auto_translate_enabled,
+    ba.alternate,
+    ba.created_at,
+    ba.updated_at,
+    ba.deleted_at
+   FROM blog_accounts ba
+     JOIN common_domains cd ON ba.common_domain_id = cd.id;

--- a/schemas/blog_post_slug_histories.sql
+++ b/schemas/blog_post_slug_histories.sql
@@ -1,0 +1,16 @@
+-- PostgreSQL
+
+CREATE TABLE blog_post_slug_histories (
+    id              bigint NOT NULL DEFAULT nextval('blog_post_slug_histories_id_seq'::regclass),
+    uuid            uuid NOT NULL DEFAULT gen_random_uuid(),
+    blog_post_id    bigint NOT NULL,
+    slug            text NOT NULL,
+    iam_account_id  bigint,
+    iam_user_id     bigint,
+    created_at      timestamp without time zone,
+    updated_at      timestamp without time zone,
+    deleted_at      timestamp without time zone,
+    CONSTRAINT blog_post_slug_histories_blog_post_id_fkey FOREIGN KEY (blog_post_id) REFERENCES blog_posts(id) ON DELETE CASCADE,
+    CONSTRAINT blog_post_slug_histories_pkey PRIMARY KEY (id),
+    CONSTRAINT blog_post_slug_histories_uuid_key UNIQUE (uuid)
+);

--- a/schemas/blog_posts.sql
+++ b/schemas/blog_posts.sql
@@ -1,0 +1,36 @@
+-- PostgreSQL
+
+CREATE TABLE blog_posts (
+    id                  bigint NOT NULL DEFAULT nextval('blog_posts_id_seq'::regclass),
+    uuid                uuid DEFAULT gen_random_uuid(), -- [ro]
+    slug                text,
+    title               text NOT NULL,
+    body                text NOT NULL, -- [ui:markdown]
+    header_image        text, -- [ui:image]
+    meta_title          text,
+    meta_description    text,
+    meta_keywords       text,
+    reply_count         integer DEFAULT 0, -- [ro]
+    read_count          bigint NOT NULL DEFAULT 0, -- [ro]
+    bonus_points        integer DEFAULT 0, -- [ro]
+    is_active           boolean DEFAULT true,
+    is_locked           boolean DEFAULT false,
+    is_pinned           boolean DEFAULT false,
+    is_draft            boolean DEFAULT true,
+    is_markdown         boolean DEFAULT false,
+    tags                text[] NOT NULL DEFAULT '{}'::text[],
+    iam_account_id      bigint, -- [ro]
+    iam_user_id         bigint, -- [ro]
+    common_category_id  bigint NOT NULL,
+    common_domain_id    bigint NOT NULL,
+    created_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at          timestamp with time zone,
+    abstract            text,
+    alternates          json DEFAULT '[]'::json,
+    alternate_of        bigint,
+    locale              text DEFAULT 'tr'::text,
+    blog_account_id     bigint,
+    faqs                json,
+    CONSTRAINT blog_posts_pkey PRIMARY KEY (id)
+);

--- a/schemas/blog_posts_perspective.sql
+++ b/schemas/blog_posts_perspective.sql
@@ -1,0 +1,48 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW blog_posts_perspective AS
+SELECT id,
+    uuid,
+    slug,
+    title,
+    body,
+    abstract,
+    header_image,
+    meta_title,
+    meta_description,
+    meta_keywords,
+    reply_count,
+    read_count,
+    bonus_points,
+    is_active,
+    is_locked,
+    is_pinned,
+    is_draft,
+    is_markdown,
+    tags,
+    iam_account_id,
+    iam_user_id,
+    common_domain_id,
+    locale,
+    alternates,
+    alternate_of,
+    faqs,
+    ( SELECT c_iu.fullname
+           FROM iam_users c_iu
+          WHERE c_iu.id = bp.iam_user_id) AS author,
+    ( SELECT c_ia.name
+           FROM iam_accounts c_ia
+          WHERE c_ia.id = bp.iam_account_id) AS team,
+    common_category_id,
+    ( SELECT c_cc.name
+           FROM common_categories c_cc
+          WHERE c_cc.id = bp.common_category_id) AS category,
+    ( SELECT c_cd.name
+           FROM common_domains c_cd
+          WHERE c_cd.id = bp.common_domain_id) AS domain_name,
+    created_at,
+    updated_at,
+    deleted_at
+   FROM blog_posts bp
+  ORDER BY created_at DESC;


### PR DESCRIPTION
Introspected the live database schema (read-only) and generated one CREATE TABLE/VIEW file per table/view owned by this module under `schemas/`. No code changes.