### PR TITLE
fix: sync alternates column onto every post in a translation group

### DIFF
--- a/src/Actions/Posts/TranslatePost.php
+++ b/src/Actions/Posts/TranslatePost.php
@@ -9,6 +9,7 @@ use NextDeveloper\Blogs\Database\Models\Accounts;
 use NextDeveloper\Blogs\Database\Models\Posts;
 use NextDeveloper\Blogs\Helpers\TranslatablePostHelper;
 use NextDeveloper\Blogs\Services\AccountsService;
+use NextDeveloper\Blogs\Services\PostsService;
 use NextDeveloper\Commons\Actions\AbstractAction;
 use NextDeveloper\Commons\Database\Models\Languages;
 use NextDeveloper\Commons\Exceptions\NotAllowedException;
@@ -217,7 +218,7 @@ class TranslatePost extends AbstractAction
                 throw new Exception("Failed to create translated post for locale: {$locale}");
             }
 
-            $this->linkAlternate($lockedPost, $translatedPost, $locale);
+            PostsService::syncAlternatesForGroup($lockedPost->id);
         });
     }
 
@@ -236,21 +237,6 @@ class TranslatePost extends AbstractAction
                     ->orWhere('blog_account_id', $destinationAccount->id);
             })
             ->exists();
-    }
-
-    private function linkAlternate(Posts $originalPost, Posts $translatedPost, string $locale): void
-    {
-        $alternates = $this->normalizeAlternates($originalPost->alternates);
-
-        $alternates[] = [
-            'id' => $translatedPost->id,
-            'locale' => $locale,
-            'title' => $translatedPost->title,
-            'slug' => $translatedPost->slug,
-        ];
-
-        $originalPost->alternates = $this->cleanAlternates($alternates);
-        $originalPost->saveQuietly();
     }
 
     /**

--- a/src/Actions/Posts/UpdatePostTranslations.php
+++ b/src/Actions/Posts/UpdatePostTranslations.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use NextDeveloper\Blogs\Database\Models\Posts;
 use NextDeveloper\Blogs\Helpers\TranslatablePostHelper;
+use NextDeveloper\Blogs\Services\PostsService;
 use NextDeveloper\Commons\Actions\AbstractAction;
 use NextDeveloper\Commons\Exceptions\NotAllowedException;
 use NextDeveloper\IAM\Helpers\UserHelper;
@@ -66,7 +67,7 @@ class UpdatePostTranslations extends AbstractAction
 
             $this->updateAlternates($validAlternates);
 
-            $this->syncAlternatesColumn($validAlternates);
+            PostsService::syncAlternatesForGroup($this->model->id);
 
             $this->setProgress(100, 'Post alternates updated successfully.');
             $this->setFinished('Post alternates updated successfully.');
@@ -219,46 +220,6 @@ class UpdatePostTranslations extends AbstractAction
 
             $translatedPost->updateQuietly($payload);
         });
-    }
-
-    /**
-     * Normalizes the alternates column on the source post so each entry
-     * reflects the latest slug/title of the translated post.
-     *
-     * @param  array<int, array<string, mixed>>  $alternates
-     */
-    private function syncAlternatesColumn(array $alternates): void
-    {
-        $ids = array_column($alternates, 'id');
-
-        if (empty($ids)) {
-            return;
-        }
-
-        $fresh = Posts::withoutGlobalScopes()
-            ->whereIn('id', $ids)
-            ->get()
-            ->keyBy('id');
-
-        $updated = [];
-
-        foreach ($alternates as $alternate) {
-            $post = $fresh->get($alternate['id']);
-
-            if (!$post) {
-                continue;
-            }
-
-            $updated[] = [
-                'id' => $post->id,
-                'locale' => strtolower(trim($alternate['locale'])),
-                'title' => $post->title,
-                'slug' => $post->slug,
-            ];
-        }
-
-        $this->model->alternates = $this->cleanAlternates($updated);
-        $this->model->saveQuietly();
     }
 
     /**

--- a/src/Console/Commands/SyncPostAlternatesCommand.php
+++ b/src/Console/Commands/SyncPostAlternatesCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NextDeveloper\Blogs\Console\Commands;
+
+use Illuminate\Console\Command;
+use NextDeveloper\Blogs\Database\Models\Posts;
+use NextDeveloper\Blogs\Services\PostsService;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
+
+/**
+ * Backfills the alternates column for existing translation groups. Historically
+ * only the root post's alternates field was ever populated by TranslatePost /
+ * UpdatePostTranslations, leaving every translated post with an empty
+ * alternates column even though it belongs to a group.
+ */
+class SyncPostAlternatesCommand extends Command
+{
+    protected $signature = 'nextdeveloper:blogs:sync-post-alternates';
+
+    protected $description = 'Rebuild the alternates column for every post translation group so each member lists all other members';
+
+    public function handle(): void
+    {
+        $rootIds = Posts::withoutGlobalScope(AuthorizationScope::class)
+            ->whereNull('alternate_of')
+            ->pluck('id');
+
+        $this->info("Checking {$rootIds->count()} root post(s) for translation groups...");
+
+        $bar = $this->output->createProgressBar($rootIds->count());
+        $bar->start();
+
+        foreach ($rootIds as $rootId) {
+            PostsService::syncAlternatesForGroup($rootId);
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info('Done.');
+    }
+}

--- a/src/Services/PostsService.php
+++ b/src/Services/PostsService.php
@@ -164,4 +164,42 @@ class PostsService extends AbstractPostsService
 
         return [];
     }
+
+    /**
+     * Rebuilds the alternates column for every post in a translation group (the
+     * root post plus every post whose alternate_of points at it) so each member
+     * lists every other member, not just the root. Historically only the root
+     * post's alternates column was ever written, leaving translated posts with
+     * an empty alternates field; this is used both to fix that going forward
+     * (TranslatePost, UpdatePostTranslations) and to backfill existing rows.
+     */
+    public static function syncAlternatesForGroup(int $rootPostId): void
+    {
+        $group = Posts::withoutGlobalScope(AuthorizationScope::class)
+            ->where('id', $rootPostId)
+            ->orWhere('alternate_of', $rootPostId)
+            ->get();
+
+        if ($group->count() < 2) {
+            return;
+        }
+
+        $entries = $group->map(fn (Posts $post) => [
+            'id' => $post->id,
+            'locale' => strtolower(trim((string) $post->locale)),
+            'title' => $post->title,
+            'slug' => $post->slug,
+        ]);
+
+        foreach ($group as $post) {
+            $ownAlternates = $entries
+                ->reject(fn (array $entry) => $entry['id'] === $post->id)
+                ->values()
+                ->toArray();
+
+            if ($post->alternates !== $ownAlternates) {
+                $post->updateQuietly(['alternates' => $ownAlternates]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Root cause: `TranslatePost`/`UpdatePostTranslations` only ever wrote the `alternates` column onto the root post, leaving translated posts (e.g. an NL alternate) with an empty `alternates` field.
- Added `PostsService::syncAlternatesForGroup()` to rebuild `alternates` on every member of a translation group (root + all posts with matching `alternate_of`).
- Added `nextdeveloper:blogs:sync-post-alternates` artisan command to backfill existing rows affected by this bug.

## Test plan
- [x] `php -l` on all changed files
- [ ] Run `php artisan nextdeveloper:blogs:sync-post-alternates` in the main app to backfill existing data