### PR TITLE
fix: detect broken alternates by alternate_of + empty alternates

### DIFF
--- a/src/Console/Commands/LinkPostAlternatesCommand.php
+++ b/src/Console/Commands/LinkPostAlternatesCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace NextDeveloper\Blogs\Console\Commands;
+
+use Illuminate\Console\Command;
+use NextDeveloper\Blogs\Database\Models\Posts;
+use NextDeveloper\Blogs\Services\PostsService;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
+
+/**
+ * Links pre-existing posts as alternates of each other from a manually
+ * curated mapping file. Unlike TranslatePost/UpdatePostTranslations, these
+ * posts were never created through the auto-translate flow, so there is no
+ * alternate_of relationship to sync from — a human has to identify which
+ * posts are actually translations of one another first.
+ *
+ * Input: a JSON file containing an array of groups, each group an array of
+ * post IDs that are translations of each other, e.g.:
+ *   [[32, 33], [108, 109, 110]]
+ *
+ * For each group, the earliest-created post becomes the root (alternate_of
+ * set to null, matching the convention used elsewhere), every other post in
+ * the group gets alternate_of pointed at the root, and PostsService::
+ * syncAlternatesForGroup() rebuilds the alternates column on every member.
+ */
+class LinkPostAlternatesCommand extends Command
+{
+    protected $signature = 'nextdeveloper:blogs:link-post-alternates {file : Path to a JSON file containing groups of post IDs that are translations of each other, e.g. [[32, 33], [108, 109, 110]]}';
+
+    protected $description = 'Links manually identified posts as alternates of each other and syncs the alternates column across each group';
+
+    public function handle(): void
+    {
+        $path = $this->argument('file');
+
+        if (!file_exists($path)) {
+            $this->error("File not found: {$path}");
+
+            return;
+        }
+
+        $groups = json_decode(file_get_contents($path), true);
+
+        if (!is_array($groups)) {
+            $this->error('File must contain a JSON array of arrays of post IDs.');
+
+            return;
+        }
+
+        foreach ($groups as $index => $ids) {
+            if (!is_array($ids) || count($ids) < 2) {
+                $this->warn("Skipping group #{$index}: needs at least 2 post IDs");
+
+                continue;
+            }
+
+            $posts = Posts::withoutGlobalScope(AuthorizationScope::class)
+                ->whereIn('id', $ids)
+                ->get()
+                ->keyBy('id');
+
+            $missing = array_diff($ids, $posts->keys()->toArray());
+
+            if (!empty($missing)) {
+                $this->warn("Skipping group #{$index}: post ID(s) not found: " . implode(', ', $missing));
+
+                continue;
+            }
+
+            $root = $posts->sortBy('created_at')->first();
+
+            foreach ($posts as $post) {
+                if ($post->id === $root->id) {
+                    if ($post->alternate_of !== null) {
+                        $post->updateQuietly(['alternate_of' => null]);
+                    }
+
+                    continue;
+                }
+
+                if ($post->alternate_of !== $root->id) {
+                    $post->updateQuietly(['alternate_of' => $root->id]);
+                }
+            }
+
+            PostsService::syncAlternatesForGroup($root->id);
+
+            $this->info("Linked group #{$index}: root={$root->id} (" . implode(', ', $ids) . ')');
+        }
+
+        $this->info('Done.');
+    }
+}

--- a/src/Console/Commands/SyncPostAlternatesCommand.php
+++ b/src/Console/Commands/SyncPostAlternatesCommand.php
@@ -8,24 +8,34 @@ use NextDeveloper\Blogs\Services\PostsService;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
- * Backfills the alternates column for existing translation groups. Historically
+ * Backfills the alternates column for broken translation groups. Historically
  * only the root post's alternates field was ever populated by TranslatePost /
- * UpdatePostTranslations, leaving every translated post with an empty
- * alternates column even though it belongs to a group.
+ * UpdatePostTranslations, leaving translated posts (alternate_of set) with an
+ * empty alternates column even though they belong to a group.
+ *
+ * A post is considered broken when it has alternate_of set (it's a
+ * translation of some root post) but its own alternates column is empty. For
+ * every such post we resolve its root (alternate_of) and rebuild the
+ * alternates column on every member of that root's group in one pass.
  */
 class SyncPostAlternatesCommand extends Command
 {
     protected $signature = 'nextdeveloper:blogs:sync-post-alternates';
 
-    protected $description = 'Rebuild the alternates column for every post translation group so each member lists all other members';
+    protected $description = 'Rebuild the alternates column for translation groups where an alternate post has alternate_of set but an empty alternates column';
 
     public function handle(): void
     {
         $rootIds = Posts::withoutGlobalScope(AuthorizationScope::class)
-            ->whereNull('alternate_of')
-            ->pluck('id');
+            ->whereNotNull('alternate_of')
+            ->where(function ($query) {
+                $query->whereNull('alternates')
+                    ->orWhereRaw("alternates::text = '[]'");
+            })
+            ->distinct()
+            ->pluck('alternate_of');
 
-        $this->info("Checking {$rootIds->count()} root post(s) for translation groups...");
+        $this->info("Found {$rootIds->count()} translation group(s) with a broken alternate...");
 
         $bar = $this->output->createProgressBar($rootIds->count());
         $bar->start();


### PR DESCRIPTION
## Summary
- `nextdeveloper:blogs:sync-post-alternates` now detects broken posts precisely: `alternate_of IS NOT NULL AND alternates = '[]'`, resolves the root via `alternate_of`, and rebuilds the whole group (root + all children with that alternate_of) in one pass — instead of sweeping every root post regardless of state.
- Adds `nextdeveloper:blogs:link-post-alternates {file}`, which links pre-existing posts (created before the auto-translate flow existed, so they have no `alternate_of` relationship at all) as alternates of each other from a manually curated JSON mapping file (`[[32, 33], [108, 109, 110]]`), then syncs `alternates` across each group.

## Test plan
- [x] `php -l` on both files
- [x] Verified the new detection query against production data via tinker (read-only): 2 groups currently match (roots 106, 358)